### PR TITLE
Escaping html tag to prevent xss

### DIFF
--- a/xmppserver/src/main/webapp/group-delete.jsp
+++ b/xmppserver/src/main/webapp/group-delete.jsp
@@ -85,7 +85,7 @@
 
 <p>
 <fmt:message key="group.delete.hint_info" />
-<b><a href="group-edit.jsp?group=<%= URLEncoder.encode(group.getName(), "UTF-8")%>"><%= group.getName() %></a></b>
+<b><a href="group-edit.jsp?group=<%= URLEncoder.encode(group.getName(), "UTF-8")%>"><%= StringUtils.escapeHTMLTags(group.getName()) %></a></b>
 <fmt:message key="group.delete.hint_info1" />
 </p>
 


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-maven-xmppserver/ 

### ⚙️ Description *

In the page used to delete the group, the (dangerous) group name characters that can cause an XSS are transformed in a way the are not dangerous any more, preserving the correct name visualization of the group name

### 💻 Technical Description *

The XSS payload was printed in the html template without escaping/encoding the dangerous characters. The proposed fix uses a method in the StringUtil class (already present in the project) that  HTML-escapes  dangerous characters  and the payload doesn't work any more

### 🐛 Proof of Concept (PoC) *
The screenshot shows the triggered XSS due to the printed payload (as is ) in the html of the page causing the xss at the opening of the page 
![Screenshot from 2021-01-19 19-58-37](https://user-images.githubusercontent.com/62958189/105080207-c57c9a00-5a90-11eb-8796-28d18992fd17.png)


### 🔥 Proof of Fix (PoF) *

The screenshot shows the payload of XSS is now HTML-escaped so the correct view of group name is preserved but the payload can create anymore a script context to trigger the XSS

![Screenshot from 2021-01-19 19-24-47](https://user-images.githubusercontent.com/62958189/105080278-e644ef80-5a90-11eb-8c57-f1a06531c9bb.png)

### 👍 User Acceptance Testing (UAT)

After the fix, the page is still working correctly allowing the user to delete the desired group


